### PR TITLE
implement "List User Orders" and "Delete User" Endpoints 

### DIFF
--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -126,7 +126,7 @@ def update_user(
     try :
         updated_user = user_service.update_user(user_id ,update_data)
         updated_user.links = UpdateUserDetailsResponse.create_hateoas_links(user_id)
-        return update_user
+        return updated_user
     except HTTPException as http_exc:
             raise http_exc
     except Exception as e:
@@ -145,7 +145,7 @@ def list_user_orders(user_id: UUID,
     
     order_service = OrderService(session)
     if current_user.id != user_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found or permission denied.")    
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not allowed to access this resource.")    
     orders = order_service.get_orders_by_user(user_id)    
     if not orders:
         return []
@@ -159,7 +159,7 @@ def delete_user(user_id: UUID,
     
     user_service = UserService(session)    
     if current_user.id != user_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found or permission denied.")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not allowed to access this resource")
     user = user_service.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")

--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -51,7 +51,7 @@ def create_user(user: CreateUserRequest ,
     user_service = UserService(session)
     try:
   # Create user record
-        return user_service.create_user()
+        return user_service.create_user(user)
     except HTTPException as http_exc:
             raise http_exc
     except Exception as e:

--- a/app/models.py
+++ b/app/models.py
@@ -58,7 +58,7 @@ class OrderStatus(SQLModel, table=True):
     updated_at: Optional[datetime] = Field(default=None, nullable=True)  
 
     # One-to-Many relationship with orders
-    orders: List[Order] = Relationship(back_populates="order_status") 
+    orders: List[Order] = Relationship(back_populates="status") 
 
 class OrderProduct(SQLModel, table=True):
     __tablename__ = "order_product"

--- a/app/schemas/user_schema.py
+++ b/app/schemas/user_schema.py
@@ -53,6 +53,7 @@ class CreateUserResponse(BaseModel):
 
     class Config:
            orm_mode = True 
+           from_attributes=True
 
 class GetUserDetailsResponse(CreateUserResponse):
     updated_at: datetime
@@ -60,6 +61,7 @@ class GetUserDetailsResponse(CreateUserResponse):
 
     class Config:
           orm_mode = True 
+          from_attributes=True
 
 
     @classmethod
@@ -77,6 +79,7 @@ class UpdateUserDetailsResponse(CreateUserResponse):
 
     class Config:
           orm_mode = True 
+          from_attributes=True
 
     @classmethod
     def create_hateoas_links(cls, user_id: UUID):

--- a/app/schemas/user_schema.py
+++ b/app/schemas/user_schema.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from decimal import Decimal
 import re
 from typing import ClassVar, Dict, List
 from uuid import UUID
@@ -105,3 +106,15 @@ class UpdateUserRequest(BaseModel):
 class ChangeRoleRequest(BaseModel):
     id : UUID
     is_admin: bool
+
+
+class UserOrdersResponse(BaseModel):
+    id: UUID
+    status: str
+    total_price: Decimal
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+        from_attributes=True

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -18,7 +18,7 @@ class AuthService:
         return None
     
     def get_user_by_id(self, id: UUID) -> User | None:
-        user = self.session.exec(select(User).where(User.ID == id)).first()
+        user = self.session.exec(select(User).where(User.id == id)).first()
         if user :
             return user
         return None

--- a/app/services/order_services.py
+++ b/app/services/order_services.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from uuid import UUID
+from sqlmodel import Session, select
+from datetime import datetime
+from app.models import Order, User
+
+router = APIRouter()
+
+class OrderService:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get_orders_by_user(self, user_id: UUID):
+        orders = self.session.exec(select(Order).where(Order.user_id == user_id)).all()
+        return orders

--- a/app/services/user_services.py
+++ b/app/services/user_services.py
@@ -12,6 +12,15 @@ class UserService:
     def __init__(self, session: Session):
         self.session = session
 
+    def user_has_active_orders(self, user_id: UUID) -> bool:
+        return self.session.exec(select(models.Order).where(models.Order.user_id == user_id, models.Order.status == 'active')).first() is not None
+    
+
+    def delete_user(self, user: models.User):
+        self.session.delete(user)
+        self.session.commit()
+
+
     def check_email_exists(self, email: str) -> bool:
         existing_user = self.session.exec(select(models.User).where(models.User.email == email)).first()
         return existing_user is not None

--- a/app/services/user_services.py
+++ b/app/services/user_services.py
@@ -34,10 +34,11 @@ class UserService:
                     status_code=status.HTTP_409_CONFLICT,
                     detail="Email already registered")
         hashed_password = get_password_hash(user.password)
+        print("hashed_password is :",hashed_password)
         db_user = models.User(id=uuid4(),
                             username=user.username,
                             email=user.email,
-                            password=hashed_password,
+                            hashed_password=hashed_password,
                             is_admin=False,
                             is_active=True,
                             created_at=datetime.now(),


### PR DESCRIPTION
This PR adds two new endpoints:
List User Orders (GET /users/{user_id}/orders): Allows users to view their own order history, with access control.
Delete User (DELETE /users/{user_id}): Enables users to delete their accounts if no active orders exist.